### PR TITLE
Fix #7 - Use Invariant Culture to use dot as decimal separator

### DIFF
--- a/src/log4net.Appender.Splunk/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
+++ b/src/log4net.Appender.Splunk/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
@@ -18,6 +18,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Globalization;
 
 namespace Splunk.Logging
 {
@@ -190,7 +191,7 @@ namespace Splunk.Logging
             DateTime datetime, string id, string level, string messageTemplate, string renderedMessage, object exception, object properties, Metadata metadata)
         {
             double epochTime = (datetime - new DateTime(1970, 1, 1)).TotalSeconds;
-            Timestamp = epochTime.ToString("#.000"); // truncate to 3 digits after floating point
+            Timestamp = epochTime.ToString("#.000", CultureInfo.InvariantCulture); // truncate to 3 digits after floating point
             this.metadata = metadata ?? new Metadata();
             Event = new LoggerEvent(id, level, messageTemplate, renderedMessage, exception, properties);
         }


### PR DESCRIPTION
If the current culture is set to a culture that uses a comma as the decimal separator, Splunk won't accept the event. This commit ensures that a dot will be used as the decimal separator for Timestamp.