### PR TITLE
Dn/batch logging+fix retries+ignore certificate

### DIFF
--- a/src/AspNetMvcApp/AspNetMvcApp.csproj
+++ b/src/AspNetMvcApp/AspNetMvcApp.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
-  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -70,9 +69,6 @@
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -206,7 +202,9 @@
     <Content Include="Scripts\umd\popper-utils.min.js" />
     <Content Include="Scripts\umd\popper.js" />
     <Content Include="Scripts\umd\popper.min.js" />
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </Content>
@@ -283,12 +281,6 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AspNetMvcApp/Controllers/HomeController.cs
+++ b/src/AspNetMvcApp/Controllers/HomeController.cs
@@ -10,9 +10,14 @@ namespace AspNetMvcApp.Controllers
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(typeof(HomeController));
 
+
         public ActionResult Index()
         {
-            log.Info("Action Index has been fired.");
+            // with batch setting of 10, it should submit 3 batches which we can observe in Fiddler
+            for (var i = 0; i < 22; i++)
+            {
+                log.Info($"Action Index has been fired.i={i}, time=" + DateTime.Now.ToString("hh:mm:ss.fff tt"));
+            }
             return View();
         }
 

--- a/src/AspNetMvcApp/Web.config
+++ b/src/AspNetMvcApp/Web.config
@@ -20,16 +20,21 @@
         <conversionPattern value="%-5level [%thread]: %message%newline" />
       </layout>
     </appender>
+    
     <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
       <ServerUrl>https://my_trial_cloud_splunk_server_name.cloud.splunk.com:8088/services/collector</ServerUrl>
       <Token>de63d82e-6f5d-4f72-a03c-018d462c30c8</Token>
-      <RetriesOnError>0</RetriesOnError>
+      <RetriesOnError>10</RetriesOnError>
+      <BatchIntevalMs>100</BatchIntevalMs>
+      <BatchSizeCount>10</BatchSizeCount>
+      <SendMode>Parallel</SendMode>
       <IgnoreCertificateErrors>True</IgnoreCertificateErrors>
       <threshold value="DEBUG" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%-5level [%thread]: %message%newline" />
       </layout>
     </appender>
+    
     <root>
       <level value="ALL" />
       <appender-ref ref="RollingLogFileAppender" />

--- a/src/AspNetMvcApp/Web.config
+++ b/src/AspNetMvcApp/Web.config
@@ -7,6 +7,7 @@
   <configSections>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
+  
   <log4net debug="true">
     <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
       <file value="logs\log.txt" />
@@ -20,8 +21,8 @@
       </layout>
     </appender>
     <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
-      <ServerUrl>http://localhost:8088</ServerUrl>
-      <Token>7856e3dd-b7d2-4b8f-b88e-61146264b727</Token>
+      <ServerUrl></ServerUrl>
+      <Token></Token>
       <RetriesOnError>0</RetriesOnError>
       <threshold value="DEBUG" />
       <layout type="log4net.Layout.PatternLayout">
@@ -34,6 +35,7 @@
       <appender-ref ref="Splunk" />
     </root>
   </log4net>
+  
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
@@ -93,10 +95,4 @@
     </modules>
     <validation validateIntegratedModeConfiguration="false" />
   </system.webServer>
-  <system.codedom>
-    <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
-    </compilers>
-  </system.codedom>
 </configuration>

--- a/src/AspNetMvcApp/Web.config
+++ b/src/AspNetMvcApp/Web.config
@@ -21,9 +21,10 @@
       </layout>
     </appender>
     <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
-      <ServerUrl></ServerUrl>
-      <Token></Token>
+      <ServerUrl>https://my_trial_cloud_splunk_server_name.cloud.splunk.com:8088/services/collector</ServerUrl>
+      <Token>de63d82e-6f5d-4f72-a03c-018d462c30c8</Token>
       <RetriesOnError>0</RetriesOnError>
+      <IgnoreCertificateErrors>True</IgnoreCertificateErrors>
       <threshold value="DEBUG" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%-5level [%thread]: %message%newline" />

--- a/src/AspNetMvcApp/packages.config
+++ b/src/AspNetMvcApp/packages.config
@@ -17,7 +17,6 @@
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net461" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />

--- a/src/AspNetWebApp/Web.config
+++ b/src/AspNetWebApp/Web.config
@@ -35,12 +35,6 @@
       <appender-ref ref="Splunk" />
     </root>
   </log4net>
-    <root>
-      <level value="ALL" />
-      <appender-ref ref="RollingLogFileAppender" />
-      <appender-ref ref="Splunk" />
-    </root>
-  </log4net>
   <system.web>
     <compilation debug="true" targetFramework="4.6.1" />
     <httpRuntime targetFramework="4.6.1" />

--- a/src/AspNetWebApp/Web.config
+++ b/src/AspNetWebApp/Web.config
@@ -20,14 +20,21 @@
       </layout>
     </appender>
     <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
-      <ServerUrl>http://localhost:8088</ServerUrl>
-      <Token>7856e3dd-b7d2-4b8f-b88e-61146264b727</Token>
+      <ServerUrl>https://my_trial_cloud_splunk_server_name.cloud.splunk.com:8088/services/collector</ServerUrl>
+      <Token>de63d82e-6f5d-4f72-a03c-018d462c30c8</Token>
       <RetriesOnError>0</RetriesOnError>
+      <IgnoreCertificateErrors>True</IgnoreCertificateErrors>
       <threshold value="DEBUG" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%-5level [%thread]: %message%newline" />
       </layout>
     </appender>
+    <root>
+      <level value="ALL" />
+      <appender-ref ref="RollingLogFileAppender" />
+      <appender-ref ref="Splunk" />
+    </root>
+  </log4net>
     <root>
       <level value="ALL" />
       <appender-ref ref="RollingLogFileAppender" />

--- a/src/ConsoleTestApp/Program.cs
+++ b/src/ConsoleTestApp/Program.cs
@@ -48,6 +48,13 @@ namespace ConsoleTestApp
                 logger.Error("Our pretend exception detected!", ex);
             }
 
+            // with batch setting of 10, it should submit 3 batches which we can observe in Fiddler
+            // the total number of messages should be 21...29. We sent 6 above, so need at least another 15
+            for (var i = 0; i < 15; i++)
+            {
+                logger.Info($"Test info message. i={i}, time=" + DateTime.Now.ToString("hh:mm:ss.fff tt"));
+            }
+
 #if DEBUG
             Console.Write("\nPress any key to continue...");
             Console.ReadKey();

--- a/src/ConsoleTestApp/log4net.config
+++ b/src/ConsoleTestApp/log4net.config
@@ -1,5 +1,4 @@
 ﻿<log4net>
-  
   <appender name="Console" type="log4net.Appender.ConsoleAppender">
     <threshold value="DEBUG" />
     <layout type="log4net.Layout.PatternLayout">
@@ -8,23 +7,19 @@
   </appender>
 
   <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
-    <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
-      <ServerUrl>https://my_trial_cloud_splunk_server_name.cloud.splunk.com:8088/services/collector</ServerUrl>
-      <Token>my_http_collector_token</Token>
-      <RetriesOnError>0</RetriesOnError>
-      <IgnoreCertificateErrors>True</IgnoreCertificateErrors>
-      <threshold value="DEBUG" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%-5level [%thread]: %message%newline" />
-      </layout>
-    </appender>
-    <root>
-      <level value="ALL" />
-      <appender-ref ref="RollingLogFileAppender" />
-      <appender-ref ref="Splunk" />
-    </root>
-  </log4net>
-
+    <ServerUrl>https://my_trial_cloud_splunk_server_name.cloud.splunk.com:8088/services/collector</ServerUrl>
+    <Token>de63d82e-6f5d-4f72-a03c-018d462c30c8</Token>
+    <RetriesOnError>10</RetriesOnError>
+    <BatchIntevalMs>100</BatchIntevalMs>
+    <BatchSizeCount>10</BatchSizeCount>
+    <SendMode>Parallel</SendMode>
+    <IgnoreCertificateErrors>True</IgnoreCertificateErrors>
+    <threshold value="DEBUG" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-5level [%thread]: %message%newline" />
+    </layout>
+  </appender>
+  
   <root>
     <level value="ALL" />
     <appender-ref ref="Console" />

--- a/src/ConsoleTestApp/log4net.config
+++ b/src/ConsoleTestApp/log4net.config
@@ -8,14 +8,22 @@
   </appender>
 
   <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
-    <ServerUrl>http://localhost:8088</ServerUrl>
-    <Token>7856e3dd-b7d2-4b8f-b88e-61146264b727</Token>
-    <RetriesOnError>0</RetriesOnError>
-    <threshold value="DEBUG" />
-    <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="%message" />
-    </layout>
-  </appender>
+    <appender name="Splunk" type="log4net.Appender.Splunk.SplunkHttpEventCollector, log4net.Appender.Splunk">
+      <ServerUrl>https://my_trial_cloud_splunk_server_name.cloud.splunk.com:8088/services/collector</ServerUrl>
+      <Token>my_http_collector_token</Token>
+      <RetriesOnError>0</RetriesOnError>
+      <IgnoreCertificateErrors>True</IgnoreCertificateErrors>
+      <threshold value="DEBUG" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%-5level [%thread]: %message%newline" />
+      </layout>
+    </appender>
+    <root>
+      <level value="ALL" />
+      <appender-ref ref="RollingLogFileAppender" />
+      <appender-ref ref="Splunk" />
+    </root>
+  </log4net>
 
   <root>
     <level value="ALL" />

--- a/src/log4net.Appender.Splunk/Splunk.Logging.Common/HttpEventCollectorSender.cs
+++ b/src/log4net.Appender.Splunk/Splunk.Logging.Common/HttpEventCollectorSender.cs
@@ -123,6 +123,7 @@ namespace Splunk.Logging
         private HttpEventCollectorFormatter formatter = null;
         // counter for bookkeeping the async tasks 
         private long activeAsyncTasksCount = 0;
+        private bool ignoreCertificateErrors;
 
         /// <summary>
         /// On error callbacks.
@@ -148,7 +149,8 @@ namespace Splunk.Logging
             SendMode sendMode,
             int batchInterval, int batchSizeBytes, int batchSizeCount,
             HttpEventCollectorMiddleware middleware,
-            HttpEventCollectorFormatter formatter = null)
+            HttpEventCollectorFormatter formatter = null,
+            bool ignoreCertificateErrors = false)
         {
             this.serializer = new JsonSerializer();
             serializer.NullValueHandling = NullValueHandling.Ignore;
@@ -163,6 +165,7 @@ namespace Splunk.Logging
             this.token = token;
             this.middleware = middleware;
             this.formatter = formatter;
+            this.ignoreCertificateErrors = ignoreCertificateErrors;
 
             // special case - if batch interval is specified without size and count
             // they are set to "infinity", i.e., batch may have any size 
@@ -189,7 +192,16 @@ namespace Splunk.Logging
             }
 
             // setup HTTP client
-            httpClient = new HttpClient();
+            if (ignoreCertificateErrors)
+            {
+                var certificateHandler = new HttpClientHandler();
+                certificateHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                certificateHandler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true;
+                httpClient = new HttpClient(certificateHandler, true);
+            }
+            else
+                httpClient = new HttpClient();
+
             httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(AuthorizationHeaderScheme, token);
         }

--- a/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
+++ b/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
@@ -86,7 +86,7 @@ namespace log4net.Appender.Splunk
 
             // Send the event to splunk
             _hecSender.Send(DateTime.Now, null, loggingEvent.Level.Name, null, loggingEvent.RenderedMessage, loggingEvent.ExceptionObject, properties, metaData);
-            // the awaiter will lock the code execution and break batch processing
+            // the sync waiting will lock the code execution and break batch processing
             //_hecSender.FlushSync();
         }
 

--- a/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
+++ b/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
@@ -21,6 +21,7 @@ namespace log4net.Appender.Splunk
         public int BatchIntevalMs { get; set; }
         public int BatchSizeCount { get; set; }
         HttpEventCollectorSender.SendMode SendMode { get; set; }
+        public bool IgnoreCertificateErrors { get; set; }
 
         /// <summary>
         /// This appender requires a <see cref="Layout"/> to be set.
@@ -40,7 +41,9 @@ namespace log4net.Appender.Splunk
                 BatchIntevalMs,                                                                     // BatchInterval - Set to 0 to disable
                 0,                                                                                  // BatchSizeBytes - Set to 0 to disable
                 BatchSizeCount,                                                                     // BatchSizeCount - Set to 0 to disable
-                new HttpEventCollectorResendMiddleware(RetriesOnError).Plugin                       // Resend Middleware with retry
+                new HttpEventCollectorResendMiddleware(RetriesOnError).Plugin,                      // Resend Middleware with retry
+                null,
+                IgnoreCertificateErrors                                                             // Ignore invalid server certificate (self-signed, etc)
             );
         }
 

--- a/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
+++ b/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
@@ -17,10 +17,10 @@ namespace log4net.Appender.Splunk
         public string Token { get; set; }
         public string Index { get; set; }
         public string Host { get; set; }
-        public int RetriesOnError { get; set; } = 0;
+        public int RetriesOnError { get; set; }
         public int BatchIntevalMs { get; set; }
         public int BatchSizeCount { get; set; }
-        HttpEventCollectorSender.SendMode SendMode { get; set; }
+        HttpEventCollectorSender.SendMode SendMode { get; set; } = HttpEventCollectorSender.SendMode.Sequential;
         public bool IgnoreCertificateErrors { get; set; }
 
         /// <summary>

--- a/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
+++ b/src/log4net.Appender.Splunk/SplunkHttpEventCollector.cs
@@ -85,7 +85,7 @@ namespace log4net.Appender.Splunk
             }
 
             // Send the event to splunk
-            _hecSender.Send(DateTime.Now, null, loggingEvent.Level.Name, null, loggingEvent.RenderedMessage, loggingEvent.ExceptionObject, properties, metaData);
+            _hecSender.Send(loggingEvent.TimeStampUtc, null, loggingEvent.Level.Name, null, loggingEvent.RenderedMessage, loggingEvent.ExceptionObject, properties, metaData);
             // the sync waiting will lock the code execution and break batch processing
             //_hecSender.FlushSync();
         }


### PR DESCRIPTION
I'm addressing several issues blocking me from logging to Splunk from MVC based cloud app.

1. The messages were logged in synchronous way, one at a time.
The app is logging around ~5000 on startup.

2. The self-signed certificate of a trial version won't work with default implementation.

3. The "retry" logic didn't work in MVC (not sure of console app) because of waiting for delay in async task called from sync task never completed. So if you currently put a breakpoint below `await Task.Delay(retryDelay)` in `HttpEventCollectorResendMiddleware` it will never be hit.

So my code changes are
1. Remove `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` as it will REQUIRE Rolsen. You don't need this for MVC project to run at all.
2. Expose options for batch processing into configuration.
3. Add option and logic for ignoring certificate errors.
4. Refactor a bit with calling `async PostEvents` from `sync Flush`, so error delays in retries will work as expected.
5. Filled `SplunkHttpEventCollector.Flush`. Expecting this to be called by log4net on app closing (not happening in dev, where I just shut the process.
TODO this bit needs further investigation to make sure log4net flushes in IIS ASP.NET site on server shut down.

Tested the changes in MVC and Console app. Didn't test the web app.
